### PR TITLE
Configures dynamic DB host for PR deployments

### DIFF
--- a/.github/workflows/dblab-branch-env.yml
+++ b/.github/workflows/dblab-branch-env.yml
@@ -86,8 +86,6 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: 22
-          envs: |
-            DBLAB_HOST=${{ secrets.DBLAB_HOST }}
           script: |
             set -e
 
@@ -96,8 +94,8 @@ jobs:
             CLONE_DB_NAME=${{ env.CLONE_DB_NAME }}
             CONTAINER=openwebui_pr_${PR_NUM}
 
-            if [ -n "$DBLAB_HOST" ]; then
-              DB_HOST="$DBLAB_HOST"
+            if [ -n ${{ secrets.DBLAB_HOST }} ]; then
+              DB_HOST=${{ secrets.DBLAB_HOST }}
             else
               DB_HOST="pr_${PR_NUM}_clone"
               docker network connect dblab-net pr_${PR_NUM}_clone || true

--- a/.github/workflows/dblab-branch-env.yml
+++ b/.github/workflows/dblab-branch-env.yml
@@ -86,24 +86,32 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: 22
+          envs: |
+            DBLAB_HOST=${{ secrets.DBLAB_HOST }}
           script: |
             set -e
+
             PR_NUM=${{ github.event.pull_request.number }}
             CLONE_PORT=${{ env.CLONE_PORT }}
             CLONE_DB_NAME=${{ env.CLONE_DB_NAME }}
             CONTAINER=openwebui_pr_${PR_NUM}
 
+            if [ -n "$DBLAB_HOST" ]; then
+              DB_HOST="$DBLAB_HOST"
+            else
+              DB_HOST="pr_${PR_NUM}_clone"
+              docker network connect dblab-net pr_${PR_NUM}_clone || true
+            fi
+
             echo "Stopping any existing container $CONTAINER"
             docker rm -f $CONTAINER || true
-
-            docker network connect dblab-net pr_${PR_NUM}_clone || true
 
             echo "Starting OpenWebUI container $CONTAINER for PR #${PR_NUM}"
             docker run -d \
               --name $CONTAINER \
               --network dblab-net \
-              -e DATABASE_URL="postgresql://${{ secrets.DBLAB_DB_USERNAME }}:${{ secrets.DBLAB_DB_PASSWORD }}@pr_${PR_NUM}_clone:${CLONE_PORT}/${CLONE_DB_NAME}" \
-              -e OLLAMA_BASE_URL="http://ollama:11434" \
+              -e DATABASE_URL="postgresql://${{ secrets.DBLAB_DB_USERNAME }}:${{ secrets.DBLAB_DB_PASSWORD }}@${DB_HOST}:${CLONE_PORT}/${CLONE_DB_NAME}" \
+              -e OLLAMA_API_BASE_URL="http://ollama:11434" \
               --label "traefik.enable=true" \
               --label "traefik.docker.network=dblab-net" \
               --label "traefik.http.routers.pr${PR_NUM}.rule=Host(\`pr-${PR_NUM}.demo-dblab.tsechoev.dev\`)" \
@@ -112,5 +120,4 @@ jobs:
               --label "traefik.http.services.pr${PR_NUM}.loadbalancer.server.port=8080" \
               ghcr.io/open-webui/open-webui:main
 
-
-            echo "PR #${PR_NUM} deployed at https://pr-${PR_NUM}.demo-dblab.tsechoev.dev"
+            echo "✅ PR #${PR_NUM} deployed at https://pr-${PR_NUM}.demo-dblab.tsechoev.dev"


### PR DESCRIPTION
Ensures PR environments utilize a dynamic database host, falling back to the dblab host if defined.
This allows deployments with local DBLab or with DBLab on different host